### PR TITLE
fix: alloc encoding buffer properly for seq layouts

### DIFF
--- a/web3.js/src/layout.ts
+++ b/web3.js/src/layout.ts
@@ -135,13 +135,25 @@ export const voteInit = (property: string = 'voteInit') => {
 };
 
 export function getAlloc(type: any, fields: any): number {
+  const getItemAlloc = (item: any): number => {
+    if (item.span >= 0) {
+      return item.span;
+    } else if (typeof item.alloc === 'function') {
+      return item.alloc(fields[item.property]);
+    } else if ('count' in item && 'elementLayout' in item) {
+      const field = fields[item.property];
+      if (Array.isArray(field)) {
+        return field.length * getItemAlloc(item.elementLayout);
+      }
+    }
+    // Couldn't determine allocated size of layout
+    return 0;
+  };
+
   let alloc = 0;
   type.layout.fields.forEach((item: any) => {
-    if (item.span >= 0) {
-      alloc += item.span;
-    } else if (typeof item.alloc === 'function') {
-      alloc += item.alloc(fields[item.property]);
-    }
+    alloc += getItemAlloc(item);
   });
+
   return alloc;
 }

--- a/web3.js/test/address-lookup-table-program.test.ts
+++ b/web3.js/test/address-lookup-table-program.test.ts
@@ -65,10 +65,7 @@ describe('AddressLookupTableProgram', () => {
     };
     expect(transaction.instructions).to.have.length(1);
     expect(extendLutParams).to.eql(
-      AddressLookupTableInstruction.decodeExtendLookupTable(
-        instruction,
-        addressesToAdd.length,
-      ),
+      AddressLookupTableInstruction.decodeExtendLookupTable(instruction),
     );
   });
 
@@ -97,10 +94,7 @@ describe('AddressLookupTableProgram', () => {
     };
     expect(transaction.instructions).to.have.length(1);
     expect(extendLutParams).to.eql(
-      AddressLookupTableInstruction.decodeExtendLookupTable(
-        instruction,
-        addressesToAdd.length,
-      ),
+      AddressLookupTableInstruction.decodeExtendLookupTable(instruction),
     );
   });
 


### PR DESCRIPTION
Some of the web3 code that handles encoding data described by buffer layouts wasn't handling sequence layouts properly. This caused the buffer to be overrun while encoding data.